### PR TITLE
Add Global Energy Monitor data to powerplant matching

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -5,6 +5,11 @@ History of Changes
 Upcoming Version
 ----------------
 
+**Bug fixes**
+
+* Fix `GEM_GGPT <https://globalenergymonitor.org/projects/global-gas-plant-tracker/>`_ interface.
+
+
 Version 0.5.5 (05.09.2022)
 -------------------------
 

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1602,7 +1602,7 @@ def GEM_GGPT(raw=False, update=False, config=None):
         .pipe(convert_to_short_name)
     )
     df.dropna(subset="Capacity", inplace=True)
-    df = df[df.Status.isin(["operating", "mothballed", "construction"])] 
+    df = df[df.Status.isin(["operating", "mothballed", "construction"])]
     df["Fueltype"] = "Natural Gas"
     df["Duration"] = np.nan
     df["Efficiency"] = np.nan

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1557,8 +1557,6 @@ def GEM_GGPT(raw=False, update=False, config=None):
         Whether to return the original dataset
     update: bool, default False
         Whether to update the data from the url.
-    header : int, Default 1
-        The zero-indexed row in which the column headings are found.
     config : dict, default None
         Add custom specific configuration,
         e.g. powerplantmatching.config.get_config(target_countries='Italy'),
@@ -1603,6 +1601,12 @@ def GEM_GGPT(raw=False, update=False, config=None):
         .pipe(set_column_name, "GEM_GGPT")
         .pipe(convert_to_short_name)
     )
+    df.dropna(subset="Capacity", inplace=True)
+    df = df[
+        (df['Status'] == "operating") |
+        (df['Status'] == "mothballed") |
+        (df['Status'] == "construction") 
+    ]
     df["Fueltype"] = "Natural Gas"
     df["Duration"] = np.nan
     df["Efficiency"] = np.nan

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1592,17 +1592,22 @@ def GEM_GGPT(raw=False, update=False, header=1, config=None):
     }
 
     set_dict = {
-        "Y": "True",
-        "N": "False",
-        "not found": "False", 
+        "Y": "CHP",
+        "N": "PP",
+        "not found": "PP",
     }
 
-    df.rename(columns=RENAME_COLUMNS, inplace=True)
-    # Consistent country names for dataset
-    df = convert_to_short_name(df)
-    df.dropna(subset="Capacity", inplace=True)
+    df = (
+        df.rename(columns=RENAME_COLUMNS)
+        .pipe(clean_name)
+        .pipe(set_column_name, "GEM_GGPT")
+        .pipe(convert_to_short_name)
+    )
     df["Fueltype"] = "Natural Gas"
+    df["Duration"] = np.nan
+    df["Efficiency"] = np.nan
     df.Technology.replace(technology_dict, inplace=True)
     df.Set.replace(set_dict, inplace=True)
+    df = df[df.columns.intersection(config.get("target_columns"))]
 
     return df

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1602,11 +1602,7 @@ def GEM_GGPT(raw=False, update=False, config=None):
         .pipe(convert_to_short_name)
     )
     df.dropna(subset="Capacity", inplace=True)
-    df = df[
-        (df['Status'] == "operating") |
-        (df['Status'] == "mothballed") |
-        (df['Status'] == "construction") 
-    ]
+    df = df[df.Status.isin(["operating", "mothballed", "construction"]) 
     df["Fueltype"] = "Natural Gas"
     df["Duration"] = np.nan
     df["Efficiency"] = np.nan

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1602,7 +1602,7 @@ def GEM_GGPT(raw=False, update=False, config=None):
         .pipe(convert_to_short_name)
     )
     df.dropna(subset="Capacity", inplace=True)
-    df = df[df.Status.isin(["operating", "mothballed", "construction"]) 
+    df = df[df.Status.isin(["operating", "mothballed", "construction"])] 
     df["Fueltype"] = "Natural Gas"
     df["Duration"] = np.nan
     df["Efficiency"] = np.nan

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1547,7 +1547,7 @@ def IRENASTAT(raw=False, update=False, config=None):
     return df
 
 
-def GEM_GGPT(raw=False, update=False, header=1, config=None):
+def GEM_GGPT(raw=False, update=False, config=None):
     """
     Importer for the GEM_GPPT gas powerplant tracker.
 
@@ -1566,7 +1566,7 @@ def GEM_GGPT(raw=False, update=False, header=1, config=None):
     """
     config = get_config() if config is None else config
     fn = get_raw_file("GEM_GGPT", update=update, config=config)
-    df = pd.read_excel(fn, sheet_name="Gas plants - data", header=header)
+    df = pd.read_excel(fn, sheet_name="Gas plants - data")
 
     if raw:
         return df

--- a/powerplantmatching/package_data/config.yaml
+++ b/powerplantmatching/package_data/config.yaml
@@ -22,7 +22,6 @@ matching_sources:
   - OPSD: Country != "Spain" and Fueltype != 'Hard Coal'
   - BEYONDCOAL
   - WIKIPEDIA
-  - GEM_GGPT
 
 fully_included_sources:
   # Make individual queries for the datasets

--- a/powerplantmatching/package_data/config.yaml
+++ b/powerplantmatching/package_data/config.yaml
@@ -22,6 +22,7 @@ matching_sources:
   - OPSD: Country != "Spain" and Fueltype != 'Hard Coal'
   - BEYONDCOAL
   - WIKIPEDIA
+  - GEM_GGPT
 
 fully_included_sources:
   # Make individual queries for the datasets
@@ -145,11 +146,11 @@ WEPP:
   net_capacity: false
   reliability_score: 4
   fn: platts_wepp.csv
-
 GEM_GGPT:
   net_capacity: false
   reliability_score: 5
-  url: https://greeninfo-network.github.io/global-gas-plant-tracker/data/data.csv
+  fn: Global-Gas-Plant-Tracker-Aug-2022.xlsx
+  url: https://github.com/pz-max/gem-coal-n-gas/raw/main/Global-Gas-Plant-Tracker-Aug-2022.xlsx
 
 # ---------------------------------------------------------------------------- #
 #                             Data Structure Config                            #

--- a/powerplantmatching/package_data/config.yaml
+++ b/powerplantmatching/package_data/config.yaml
@@ -150,7 +150,7 @@ GEM_GGPT:
   net_capacity: false
   reliability_score: 4
   fn: Global-Gas-Plant-Tracker-Aug-2022.xlsx
-  url: https://github.com/pz-max/gem-coal-n-gas/raw/main/Global-Gas-Plant-Tracker-Aug-2022.xlsx
+  url: https://github.com/pz-max/gem-powerplant-data/raw/main/Global-Gas-Plant-Tracker-Aug-2022.xlsx
 
 # ---------------------------------------------------------------------------- #
 #                             Data Structure Config                            #

--- a/powerplantmatching/package_data/config.yaml
+++ b/powerplantmatching/package_data/config.yaml
@@ -22,6 +22,7 @@ matching_sources:
   - OPSD: Country != "Spain" and Fueltype != 'Hard Coal'
   - BEYONDCOAL
   - WIKIPEDIA
+  - GEM_GGPT
 
 fully_included_sources:
   # Make individual queries for the datasets
@@ -147,7 +148,7 @@ WEPP:
   fn: platts_wepp.csv
 GEM_GGPT:
   net_capacity: false
-  reliability_score: 5
+  reliability_score: 4
   fn: Global-Gas-Plant-Tracker-Aug-2022.xlsx
   url: https://github.com/pz-max/gem-coal-n-gas/raw/main/Global-Gas-Plant-Tracker-Aug-2022.xlsx
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

Closes https://github.com/PyPSA/powerplantmatching/issues/76

## Change proposed in this Pull Request

<!--- Provide a general, short summary of your changes in the title above -->
We experienced especially in a couple of African countries that our open data on gas and coal powerplants is not seemingly complete. This PR should add a new source to powerplantmatching to potentially improve the data coverage.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added a note to release notes `doc/release_notes.rst`.
- [ ] I have used `pre-commit run --all` to lint/format/check my contribution
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have adjusted the docstrings in the code appropriately.
