### PR TITLE
Add optional new data source to accommodate custom data

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -7,7 +7,7 @@ Upcoming Version
 
 **New Features**
 
-* New `EXTERNAL_DATABASE` inferface to integrate additional custom data of raw data matching the powerplantmatching format.
+* New `EXTERNAL_DATABASE` interface to integrate additional custom data of raw data matching the powerplantmatching format.
 
 **Bug fixes**
 

--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -5,6 +5,10 @@ History of Changes
 Upcoming Version
 ----------------
 
+**New Features**
+
+* New `EXTERNAL_DATABASE` inferface to integrate additional custom data of raw data matching the powerplantmatching format.
+
 **Bug fixes**
 
 * Fix `GEM_GGPT <https://globalenergymonitor.org/projects/global-gas-plant-tracker/>`_ interface.

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1663,7 +1663,8 @@ def EXTERNAL_DATABASE(config=None):
         return pd.DataFrame()
     
     df = pd.read_csv(
-        get_raw_file("EXTERNAL_DATABASE", update=True, config=config), low_memory=False
+        get_raw_file("EXTERNAL_DATABASE", update=True, config=config),
+        low_memory=False,
     )
     df = (df
       .loc[lambda df: df.Country.isin(config['target_countries'])]

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1647,3 +1647,27 @@ def GEM_GGPT(raw=False, update=False, config=None):
     df = df.pipe(config_filter, config)
 
     return df
+
+
+def EXTERNAL_DATABASE(config=None):
+    """
+    Importer for external custom databases.
+    Parameters
+    ----------
+    config : dict, default None
+        Add custom specific configuration,
+        e.g. powerplantmatching.config.get_config(target_countries='Italy'),
+        defaults to powerplantmatching.config.get_config()
+    """
+    if config is None:
+        return pd.DataFrame()
+    
+    df = pd.read_csv(
+        get_raw_file("EXTERNAL_DATABASE", update=True, config=config), low_memory=False
+    )
+    df = (df
+      .loc[lambda df: df.Country.isin(config['target_countries'])]
+      .pipe(set_column_name, 'EXTERNAL_DATABASE')
+      )
+
+    return 

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1649,11 +1649,15 @@ def GEM_GGPT(raw=False, update=False, config=None):
     return df
 
 
-def EXTERNAL_DATABASE(config=None):
+def EXTERNAL_DATABASE(raw=False, update=True, config=None):
     """
     Importer for external custom databases.
     Parameters
     ----------
+    raw : boolean, default False
+        Whether to return the original dataset
+    update: bool, default True (unused)
+        Whether to update the data from the url.
     config : dict, default None
         Add custom specific configuration,
         e.g. powerplantmatching.config.get_config(target_countries='Italy'),
@@ -1663,6 +1667,10 @@ def EXTERNAL_DATABASE(config=None):
         return pd.DataFrame()
 
     df = pd.read_csv(config["EXTERNAL_DATABASE"]["fn"], low_memory=False)
+
+    if raw:
+        return df
+
     df = df.pipe(set_column_name, "EXTERNAL_DATABASE").pipe(config_filter, config)
 
     return df

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1661,13 +1661,8 @@ def EXTERNAL_DATABASE(config=None):
     """
     if config is None:
         return pd.DataFrame()
-    
-    df = pd.read_csv(
-        config["EXTERNAL_DATABASE"]["fn"], low_memory=False
-    )
-    df = (df
-      .pipe(set_column_name, 'EXTERNAL_DATABASE')
-      .pipe(config_filter, config)
-    )
+
+    df = pd.read_csv(config["EXTERNAL_DATABASE"]["fn"], low_memory=False)
+    df = df.pipe(set_column_name, "EXTERNAL_DATABASE").pipe(config_filter, config)
 
     return df

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1661,14 +1661,13 @@ def EXTERNAL_DATABASE(config=None):
     """
     if config is None:
         return pd.DataFrame()
-    
+
     df = pd.read_csv(
         get_raw_file("EXTERNAL_DATABASE", update=True, config=config),
         low_memory=False,
     )
-    df = (df
-      .loc[lambda df: df.Country.isin(config['target_countries'])]
-      .pipe(set_column_name, 'EXTERNAL_DATABASE')
-      )
+    df = df.loc[lambda df: df.Country.isin(config["target_countries"])].pipe(
+        set_column_name, "EXTERNAL_DATABASE"
+    )
 
     return df

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1661,13 +1661,13 @@ def EXTERNAL_DATABASE(config=None):
     """
     if config is None:
         return pd.DataFrame()
-
+    
     df = pd.read_csv(
-        get_raw_file("EXTERNAL_DATABASE", update=True, config=config),
-        low_memory=False,
+        config["EXTERNAL_DATABASE"]["fn"], low_memory=False
     )
-    df = df.loc[lambda df: df.Country.isin(config["target_countries"])].pipe(
-        set_column_name, "EXTERNAL_DATABASE"
+    df = (df
+      .pipe(set_column_name, 'EXTERNAL_DATABASE')
+      .pipe(config_filter, config)
     )
 
     return df


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

Closes # (if applicable).

## Change proposed in this Pull Request
In this PR, we propose to include an external raw dataset provided as a csv file and incorporated into the data matching.
This can be useful to add additional datasets in the matching process.
In pypsa-earth, this feature is useful to accommodate custom processed data obtained through osm and we believe it can be helpful for other cases.
Merging this PR would be helpful to change the dependency of powerplantmatching from the current fortk to the may repository

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have adjusted the docstrings in the code appropriately.
