### PR TITLE
Enhance configuration flexibility

### DIFF
--- a/powerplantmatching/collection.py
+++ b/powerplantmatching/collection.py
@@ -43,6 +43,7 @@ def collect(
     update=False,
     reduced=True,
     config=None,
+    extend_config=None,
     **dukeargs,
 ):
     """
@@ -57,6 +58,11 @@ def collect(
         Do an horizontal update (True) or read from the cache file (False)
     reduced : bool
         Switch as to return the reduced (True) or matched (False) dataset.
+    config : dict
+        Configuration file of powerplantmatching
+    extend_config : dict
+        Configuration input dictionary to be merged into the default
+        configuration data
     **dukeargs : keyword-args for duke
     """
 
@@ -64,6 +70,9 @@ def collect(
 
     if config is None:
         config = get_config()
+    
+    if extend_config is not None:
+        config.update(extend_config)
 
     def df_by_name(name):
         conf = config[name]

--- a/powerplantmatching/collection.py
+++ b/powerplantmatching/collection.py
@@ -43,7 +43,7 @@ def collect(
     update=False,
     reduced=True,
     config=None,
-    extend_config=None,
+    config_update=None,
     **dukeargs,
 ):
     """
@@ -60,7 +60,7 @@ def collect(
         Switch as to return the reduced (True) or matched (False) dataset.
     config : dict
         Configuration file of powerplantmatching
-    extend_config : dict
+    config_update : dict
         Configuration input dictionary to be merged into the default
         configuration data
     **dukeargs : keyword-args for duke
@@ -71,8 +71,8 @@ def collect(
     if config is None:
         config = get_config()
 
-    if extend_config is not None:
-        config.update(extend_config)
+    if config_update is not None:
+        config.update(config_update)
 
     def df_by_name(name):
         conf = config[name]

--- a/powerplantmatching/collection.py
+++ b/powerplantmatching/collection.py
@@ -70,7 +70,7 @@ def collect(
 
     if config is None:
         config = get_config()
-    
+
     if extend_config is not None:
         config.update(extend_config)
 


### PR DESCRIPTION
Closes # (if applicable).

## Change proposed in this Pull Request

This PR aims at providing a flexible interface to accommodate custom configuration files.
In particular:
- the docstring of config is added to collect function
- the new extend_config option is added to collect function, whose goal is to update the default config file

Unsure if this is a wanted feature.
I'm thinking that as a workaround, someone may update the config externally, though this is easier for the user.
Currenly, we have this feature in the fork for pypsa-earth.


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
- [x] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have adjusted the docstrings in the code appropriately.
