### PR TITLE
Update docs link to powerplants .csv

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -10,7 +10,7 @@ just call
    pm.powerplants(from_url=True)
 
 which will parse and store the `actual dataset of powerplants of this
-repository <https://raw.githubusercontent.com/FRESNA/powerplantmatching/master/matched_data_red.csv>`__.
+repository <https://github.com/PyPSA/powerplantmatching/blob/master/powerplants.csv>`__.
 Setting ``from_url=False`` (default) will load all the necessary data
 files and combine them. Note that this might take some minutes.
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

## Change proposed in this Pull Request

URL was still pointing to the FRESNA version.

Note that the link to the comparison figure (`https://raw.githubusercontent.com/FRESNA/powerplantmatching/master/matching_analysis/factor_plot_Matched%20Data.png`) is also outdated, but I couldn't find an up to date version of that image to link to. I assume it can be generated by the [analysis/compare-with-entsoe-stats.py](https://github.com/PyPSA/powerplantmatching/blob/master/analysis/compare-with-entsoe-stats.py) script, but I can not get that script to work.

<!--- Provide a general, short summary of your changes in the title above -->


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added a note to release notes `doc/release_notes.rst`.
- [ ] I have used `pre-commit run --all` to lint/format/check my contribution
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [ ] I have adjusted the docstrings in the code appropriately.
