### PR TITLE
Fix hash issues with special characters

### DIFF
--- a/powerplantmatching/core.py
+++ b/powerplantmatching/core.py
@@ -112,7 +112,12 @@ def get_config(filename=None, **overrides):
     if len(dict(**overrides)) == 0:
         config["hash"] = "default"
     else:
-        config["hash"] = encodebytes(sha1digest).decode("ascii")[2:12]
+        config["hash"] = (
+            encodebytes(sha1digest)
+            .decode("ascii")[2:12]
+            .replace("\\", "")
+            .replace("/", "")
+        )
 
     if not isdir(_data_out(".", config)):
         makedirs(abspath(_data_out(".", config)))


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

Closes # (if applicable).

## Change proposed in this Pull Request

When using PyPSA-Earth, we found some issues with the hash having special characters

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [ ] I have adjusted the docstrings in the code appropriately.
