### PR TITLE
add replacement for FIAS and some OPSD download links

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -4,7 +4,9 @@ History of Changes
 
 .. Upcoming Version
 .. ----------------
+**New Features**
 
+* Replace unstable FIAS and OPSD download links by new provider
 
 Version 0.5.6 (13.02.2023)
 -------------------------

--- a/powerplantmatching/package_data/config.yaml
+++ b/powerplantmatching/package_data/config.yaml
@@ -66,7 +66,7 @@ CARMA:
   fn: Full_CARMA_2009_Dataset_1.csv
 ENTSOE:
   reliability_score: 5
-  url: https://vfs.fias.science/f/ebbdf6ba8c/?raw=1
+  url: https://raw.githubusercontent.com/pypsa-meets-earth/ppm-data-backup/main/entsoe_powerplants.csv
   fn: entsoe_powerplants.csv
 ENTSOE-EIC:
   url: https://eepublicdownloads.entsoe.eu/eic-codes-csv/W_eiccodes.csv
@@ -78,12 +78,12 @@ JRC:
 GEO:
   net_capacity: false
   reliability_score: 3
-  url: https://vfs.fias.science/f/b4607c76b4/?raw=1
+  url: https://raw.githubusercontent.com/pypsa-meets-earth/ppm-data-backup/main/global_energy_observatory_power_plants.csv
   fn: global_energy_observatory_power_plants.csv
 GEO_units:
   net_capacity: false
   reliability_score: 3
-  url: https://vfs.fias.science/f/3f4cc3876f/?raw=1
+  url: https://raw.githubusercontent.com/pypsa-meets-earth/ppm-data-backup/main/global_energy_observatory_ppl_units.csv
   fn: global_energy_observatory_ppl_units.csv
 GPD:
   reliability_score: 3
@@ -92,7 +92,7 @@ GPD:
   url: https://wri-dataportal-prod.s3.amazonaws.com/manual/global_power_plant_database_v_1_3.zip
 WIKIPEDIA:
   reliability_score: 4
-  url: https://vfs.fias.science/f/c49203915f/?raw=1
+  url: https://raw.githubusercontent.com/pypsa-meets-earth/ppm-data-backup/main/nuclear_plants_from_wikipedia.csv
   fn: nuclear_plants_from_wikipedia.csv
 IWPDCY:
   aggregated_units: true
@@ -101,11 +101,11 @@ IWPDCY:
 OPSD_DE:
   reliability_score: 5
   fn: conventional_power_plants_DE.csv
-  url: https://data.open-power-system-data.org/conventional_power_plants/2020-10-01/conventional_power_plants_DE.csv
+  url: https://raw.githubusercontent.com/pypsa-meets-earth/ppm-data-backup/main/conventional_power_plants_DE.csv
 OPSD_EU:
   reliability_score: 5
   fn: conventional_power_plants_EU.csv
-  url: https://data.open-power-system-data.org/conventional_power_plants/2020-10-01/conventional_power_plants_EU.csv
+  url: https://raw.githubusercontent.com/pypsa-meets-earth/ppm-data-backup/main/conventional_power_plants_EU.csv
 OPSD_VRE:
   url: https://data.open-power-system-data.org/renewable_power_plants/2020-08-25/renewable_power_plants_EU.csv
   fn: renewable_power_plants_EU.csv

--- a/powerplantmatching/package_data/config.yaml
+++ b/powerplantmatching/package_data/config.yaml
@@ -62,7 +62,7 @@ IRENA:
 CARMA:
   net_capacity: false
   reliability_score: 1
-  url: https://vfs.fias.science/f/e1d9d9d587/?raw=1
+  url: https://raw.githubusercontent.com/pypsa-meets-earth/ppm-data-backup/main/Full_CARMA_2009_Dataset_1.csv
   fn: Full_CARMA_2009_Dataset_1.csv
 ENTSOE:
   reliability_score: 5


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->
## Change proposed in this Pull Request
Some data is frequently downloaded from FIAS and OPSD but throttled from the server provider leading occasionally to errors in models like [PyPSA-Eur](https://github.com/PyPSA/pypsa-eur/actions/runs/4862908358/jobs/8669876366#step:11:644) and [PyPSA-Earth](https://github.com/pypsa-meets-earth/pypsa-earth/actions/runs/4902138544). Further, there is a need to move away from the FIAS server as the association from FH is soon running out.

This PR moves the data to the easy-to-maintain GitHub repo: https://github.com/pypsa-meets-earth/ppm-data-backup which allows PR's to add new data. Limited upload per commit on Github = 50MB.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
