### PR TITLE
add gem-latest

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -9,6 +9,8 @@ History of Changes
 * Updates the following Global Energy Monitor data according to latest May 2023 release: 
   * `GSPT`, solar power plant
   * `GWPT`, wind power plant
+* Changing Global Energy Monitor dataset name to -latest to avoid data update PRs in powerplantmatching
+  but rather encourage updates in `Global Energy Monitor data repo <https://github.com/pz-max/gem-powerplant-data>`__.
 
 
 Version 0.5.7 (30.05.2023)

--- a/powerplantmatching/package_data/config.yaml
+++ b/powerplantmatching/package_data/config.yaml
@@ -167,43 +167,43 @@ GGPT:
   net_capacity: false
   reliability_score: 4
   fn: Global-Gas-Plant-Tracker-GGPT-February-2023-v2.csv
-  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Gas-Plant-Tracker-GGPT-February-2023-v2.csv
+  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Gas-Plant-Tracker-GGPT-latest.csv
 GCPT:
   net_capacity: false
   reliability_score: 5
   fn: Global-Coal-Plant-Tracker-January-2023.csv
-  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Coal-Plant-Tracker-January-2023.csv
+  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Coal-Plant-Tracker-latest.csv
 GGTPT:
   net_capacity: false
   reliability_score: 4
   fn: Global-Geothermal-Power-Tracker-January-2023.csv
-  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Geothermal-Power-Tracker-January-2023.csv
+  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Geothermal-Power-Tracker-latest.csv
 GWPT:
   net_capacity: false
   reliability_score: 4
   fn: Global-Wind-Power-Tracker-January-2023.csv
-  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Wind-Power-Tracker-May-2023.csv
+  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Wind-Power-Tracker-latest.csv
 GSPT:
   net_capacity: false
   reliability_score: 4
   fn: Global-Solar-Power-Tracker-January-2023.csv
-  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Solar-Power-Tracker-May-2023.csv
+  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Solar-Power-Tracker-latest.csv
 GBPT:
   net_capacity: false
   reliability_score: 4
   fn: Global-Bioenergy-Power-Tracker-January-2023.csv
-  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Bioenergy-Power-Tracker-January-2023.csv
+  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Bioenergy-Power-Tracker-latest.csv
 GNPT:
   net_capacity: false
   reliability_score: 4
   fn: Global-Nuclear-Power-Tracker-January-2023.csv
-  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Nuclear-Power-Tracker-January-2023.csv
+  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Nuclear-Power-Tracker-latest.csv
 
 GHPT:
   net_capacity: false
   reliability_score: 4
   fn: Global-Hydropower-Tracker-May-2023.csv
-  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Hydropower-Tracker-May-2023.csv
+  url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Hydropower-Tracker-latest.csv
 # ---------------------------------------------------------------------------- #
 #                             Data Structure Config                            #
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Change proposed in this Pull Request
Building on #121. With new Global Energy Monitor data, we had to update our intermediate database at https://github.com/pz-max/gem-powerplant-data and also powerplantmatching. This PR renames the GEM data link to latest instead of referring to a specific date. This requires only data updates in our intermediate database.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution