### PR TITLE
deprecation: FutureWarning: The behavior of array concatenation with …

### DIFF
--- a/powerplantmatching/export.py
+++ b/powerplantmatching/export.py
@@ -73,7 +73,8 @@ def map_bus(df, buses):
     """
     df = get_obj_if_Acc(df)
     kdtree = KDTree(buses[["x", "y"]])
-    buses_i = buses.index.append(pd.Index([np.nan]))
+    non_empty_buses = buses.dropna().index
+    buses_i = non_empty_buses.append(pd.Index([np.nan]))
     return df.assign(bus=buses_i[kdtree.query(df[["lon", "lat"]].values)[1]])
 
 


### PR DESCRIPTION
…empty entries is deprecated.

addresses:

```
 /home/runner/micromamba/envs/pypsa-eur/lib/python3.11/site-packages/powerplantmatching/export.py:76: FutureWarning: The behavior of array concatenation with empty entries is deprecated. In a future version, this will no longer exclude empty items when determining the result dtype. To retain the old behavior, exclude the empty entries before the concat operation.
  buses_i = buses.index.append(pd.Index([np.nan]))