### PR TITLE
Add Status filter to GCPT and improve performances

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -5,6 +5,10 @@ History of Changes
 .. Upcoming Version
 .. ----------------
 
+* fix the filtering of GCPT/GEM coal database by Status.
+* add add technology renaming for GWPT/GEM wind dataset.
+* improve performances of GEM data processing.
+
 Version 0.5.11 (05.02.2024)
 ---------------------------
 

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1752,16 +1752,17 @@ def GCPT(raw=False, update=False, config=None):
         .pipe(set_column_name, "GCPT")
         .pipe(convert_to_short_name)
         .dropna(subset="Capacity")
-        .pipe(lambda x: x.replace({"Fueltype": fueltype_dict}))
-        .pipe(lambda x: x.assign(Technology="Steam Turbine"))
-        .pipe(lambda x: x.assign(Set="PP"))
         .assign(
             DateIn=df["DateIn"].apply(pd.to_numeric, errors="coerce"),
             DateOut=df["DateOut"].apply(pd.to_numeric, errors="coerce"),
             lat=df["lat"].apply(pd.to_numeric, errors="coerce"),
             lon=df["lon"].apply(pd.to_numeric, errors="coerce"),
         )
+        .query("Status in ['operating','mothballed','construction']")
         .pipe(lambda x: x[df.columns.intersection(config.get("target_columns"))])
+        .pipe(lambda x: x.replace({"Fueltype": fueltype_dict}))
+        .pipe(lambda x: x.assign(Technology="Steam Turbine"))
+        .pipe(lambda x: x.assign(Set="PP"))
         .pipe(config_filter, config)
     )
 
@@ -1873,6 +1874,7 @@ def GWPT(raw=False, update=False, config=None):
         )
         .query("Status in ['operating','mothballed','construction']")
         .pipe(lambda x: x[df.columns.intersection(config.get("target_columns"))])
+        .pipe(lambda x: x.replace({"Technology": technology_dict}))
         .assign(Fueltype="Wind")
         .assign(Set="PP")
         .pipe(config_filter, config)
@@ -1925,7 +1927,6 @@ def GSPT(raw=False, update=False, config=None):
         .pipe(set_column_name, "GSPT")
         .pipe(convert_to_short_name)
         .dropna(subset="Capacity")
-        .pipe(lambda x: x.replace({"Technology": technology_dict}))
         .assign(
             DateIn=df["DateIn"].apply(pd.to_numeric, errors="coerce"),
             DateOut=df["DateOut"].apply(pd.to_numeric, errors="coerce"),
@@ -1934,6 +1935,7 @@ def GSPT(raw=False, update=False, config=None):
         )
         .query("Status in ['operating','mothballed','construction']")
         .pipe(lambda x: x[df.columns.intersection(config.get("target_columns"))])
+        .pipe(lambda x: x.replace({"Technology": technology_dict}))
         .assign(Fueltype="Solar")
         .assign(Set="PP")
         .pipe(config_filter, config)
@@ -2004,10 +2006,10 @@ def GGPT(raw=False, update=False, config=None):
             lon=df["lon"].apply(pd.to_numeric, errors="coerce"),
             Capacity=lambda df: pd.to_numeric(df.Capacity, "coerce"),
         )
-        .pipe(lambda x: x.replace({"Technology": technology_dict}))
-        .pipe(lambda x: x.replace({"Set": set_dict}))
         .query("Status in ['operating','mothballed','construction']")
         .pipe(lambda x: x[df.columns.intersection(config.get("target_columns"))])
+        .pipe(lambda x: x.replace({"Technology": technology_dict}))
+        .pipe(lambda x: x.replace({"Set": set_dict}))
         .assign(Fueltype="Natural Gas")
         .pipe(config_filter, config)
     )
@@ -2067,8 +2069,8 @@ def GHPT(raw=False, update=False, config=None):
             lon=df["lon"].apply(pd.to_numeric, errors="coerce"),
         )
         .query("Status in ['operating','construction']")
-        .pipe(lambda x: x.replace({"Technology": technology_dict}))
         .pipe(lambda x: x[df.columns.intersection(config.get("target_columns"))])
+        .pipe(lambda x: x.replace({"Technology": technology_dict}))
         .assign(Fueltype="Hydro")
         .assign(Set="PP")
         .pipe(config_filter, config)

--- a/powerplantmatching/matching.py
+++ b/powerplantmatching/matching.py
@@ -153,7 +153,7 @@ def cross_matches(sets_of_pairs, labels=None):
             else:
                 matches = pd.concat([matches, match_base], sort=True)
 
-    if matches.empty:
+    if matches is None or matches.empty:
         logger.warn("No matches found")
         return pd.DataFrame(columns=labels)
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

Closes #153 

## Change proposed in this Pull Request

- Adds a filtering on the status column for GCPT database, similarly to the other GEM databases
- Restore a missing technology-specification for the GWPT database
- Revise the ordering of selected replacing in GEM databases to improve perfomances: the assign/replace are performed after the filtering

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
- [x] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have adjusted the docstrings in the code appropriately.
