### PR TITLE
Remove disused reference to distutils.debug

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -5,6 +5,8 @@ History of Changes
 .. Upcoming Version
 .. ----------------
 
+* Bugfix to ensure compatibility with python 3.12.
+
 Version 0.5.13 (25.04.2024)
 ---------------------------
 

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -22,7 +22,6 @@ import logging
 import os
 import re
 import xml.etree.ElementTree as ET
-from distutils.log import debug
 from zipfile import ZipFile
 
 import entsoe


### PR DESCRIPTION
Distutils has been removed from the standard library in python 3.12. If you try to install powerplantmatching in a clean environment with python 3.12 right now, you get:

````
koen-uit-desktop · powerplantmatching > source .venv/bin/activate   
(.venv) koen-uit-desktop · powerplantmatching > pip install -e .      
[...]
(.venv) koen-uit-desktop · powerplantmatching > python              
Python 3.12.2 (main, Feb 21 2024, 00:00:00) [GCC 14.0.1 20240217 (Red Hat 14.0.1-0)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import powerplantmatching as pm
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/koen/Dokument/UiT/Research/Modelling/powerplantmatching/powerplantmatching/__init__.py", line 38, in <module>
    from . import core, data, heuristics, plot, utils
  File "/home/koen/Dokument/UiT/Research/Modelling/powerplantmatching/powerplantmatching/data.py", line 25, in <module>
    from distutils.log import debug
ModuleNotFoundError: No module named 'distutils'
````

No problem: the offending line of code is unnecessary anyway as the `debug` function is never used anywhere!

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [ ] I have adjusted the docstrings in the code appropriately.
