### PR TITLE
Add Marktstammdatenregister (MaStR)

### DIFF
--- a/powerplantmatching/cleaning.py
+++ b/powerplantmatching/cleaning.py
@@ -17,6 +17,7 @@
 """
 Functions for vertically cleaning a dataset.
 """
+
 from __future__ import absolute_import, print_function
 
 import logging
@@ -449,7 +450,10 @@ def aggregate_units(
 
     df = cliques(df, duplicates)
     df = df.groupby("grouped").agg(props_for_groups)
-    df[str_cols] = df[str_cols].replace("", np.nan)
+
+    # Downcasting in replace is deprecated
+    with pd.option_context("future.no_silent_downcasting", True):
+        df[str_cols] = df[str_cols].replace("", np.nan).infer_objects(copy=False)
 
     df = (
         df.assign(

--- a/powerplantmatching/package_data/config.yaml
+++ b/powerplantmatching/package_data/config.yaml
@@ -24,6 +24,7 @@ matching_sources:
   - BEYONDCOAL
   - WIKIPEDIA
   - GEM
+  - MASTR
 
 # fully_included_sources, these sources are included even without match to the final dataset
 fully_included_sources:
@@ -195,6 +196,14 @@ GHPT:
   reliability_score: 4
   fn: Global-Hydropower-Tracker-May-2023.csv
   url: https://raw.githubusercontent.com/pz-max/gem-powerplant-data/main/Global-Hydropower-Tracker-latest.csv
+
+MASTR:
+  net_capacity: true
+  reliability_score: 8
+  fn: bnetza_open_mastr_2023-08-08_B.zip
+  url: https://zenodo.org/records/8225106/files/bnetza_open_mastr_2023-08-08_B.zip
+
+  
 # ---------------------------------------------------------------------------- #
 #                             Data Structure Config                            #
 # ---------------------------------------------------------------------------- #
@@ -273,6 +282,7 @@ target_fueltypes:
       combined cycle,
       fossil gas,
       mixed fossil fuels,
+      erdgas
     ]
   Hydro:
     [
@@ -285,9 +295,9 @@ target_fueltypes:
       hydroelectric,
       wasserkraft,
     ]
-  Hard Coal: [coal, coke]
-  Lignite: [brown coal, lignite, peat]
-  Oil: [oil, diesel]
+  Hard Coal: [coal, coke, steinkohle]
+  Lignite: [brown coal, lignite, peat, braunkohle]
+  Oil: [oil, diesel, mineralölprodukte]
   Geothermal: ""
   Solar: ""
   Waste: ""


### PR DESCRIPTION
Closes #16

## Change proposed in this Pull Request
Adds Marktstammdatenregister via [open-MaStR](https://github.com/OpenEnergyPlatform/open-MaStR). 

There are a few issues:
- open-mastr provides a bulk download of all the cleaned datasets on zenodo. But as a `.zip`, so we have to download everything. We could use the API instead, but then the user has to pass a token.
- These datasets are huge with many small power plants. I have now filtered out all plants with a capacity of less than 1 MW. Otherwise `powerplant.aggregate_units()` takes too long. Solar and wind are also currently not included.
	- Performance can be improved I think, but the main bottleneck is probably Duke and not on ours side
- Validation is not done yet, I wait for the ENTSOE token to run `compare-with-entsoe-stats.py`, but below is a first plot

[Dataset](https://zenodo.org/records/8225106)
File Name | Number of entrys | Entrys with less than 1 MW capacity
-- | -- | --
_biomass.csv | 22284 | 21240 (95.32%)
_combustion.csv | 85424 | 81776 (95.73%)
_nuclear.csv | 6 | 0 (0.00%)
_hydro.csv | 8657 | 7859 (90.78%)
_wind.csv | 34798 | 6729 (19.34%)



![output](https://github.com/PyPSA/powerplantmatching/assets/62255395/ec32c2fc-7359-49ea-ba59-b88d1cdf9470)


## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added a note to release notes `doc/release_notes.rst`.
- [ ] I have used `pre-commit run --all` to lint/format/check my contribution
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [ ] I have adjusted the docstrings in the code appropriately.