### PR TITLE
fix for duplicated non-german opsd conventional power plants from opsd_de csv file

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -13,6 +13,8 @@ Version 0.6.0 (18.09.2024)
 * Bugfix: Consistently rename countries, affecting power plants in Czech Republic and
   Moldova (https://github.com/PyPSA/powerplantmatching/pull/204).
 
+* Bugfix: Remove duplicate conventional power plants coming from different OPSD input files
+
 * See full list of changes `here <https://github.com/PyPSA/powerplantmatching/releases/tag/v0.6.0>`__.
 
 Version 0.5.19 (16.09.2024)

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -191,6 +191,7 @@ def OPSD(
     opsd_DE = (
         opsd_DE.rename(columns=str.title)
         .rename(columns=DE_RENAME_COLUMNS)
+        .query("Country == 'DE'")
         .assign(
             Name=lambda d: d.Name_Bnetza.fillna(d.Name_Uba),
             Fueltype=lambda d: d.Fueltype.fillna(d.Energy_Source_Level_1),


### PR DESCRIPTION
Currently, there is a bug when processing the OPSD input data for conventional power plants as the `opsd_de.csv` file contains 30 entries for PHS and RoR powerplants from AT, CH and LU that are also included in the `opsd_eu.csv` file. As these were not filtered out when processing both files, they appeared twice in the final opsd data set.

## Difference
OPSD capacities in GW before and after the change:
Before:
<img width="681" alt="opsd_old_table" src="https://github.com/user-attachments/assets/2dc82f6b-09c4-46b6-8df9-042fc55f4409" />
After:
<img width="684" alt="opsd_new_table" src="https://github.com/user-attachments/assets/cc43175a-4b6a-470f-9bc9-83bfafaf1f7e" />

The fix in this PR leads to the following dif in capacities for the OPSD dataset:

![opsd_dif](https://github.com/user-attachments/assets/d611a0d0-dd0b-411b-ab57-f2e7a2922c07)

## Change proposed in this Pull Request

Filters out only German power plants when processing the `opsd_de.csv` file.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

## Checklist
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [ ] I have used `pre-commit run --all` to lint/format/check my contribution
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [ ] I have adjusted the docstrings in the code appropriately.
