### PR TITLE
chore: Deprecate python==3.9, officially support python==3.13

### DIFF
--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
         cache: 'pip'
 
     - name: Install dependencies

--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -6,6 +6,9 @@ Upcoming Version
 
 * Update Marktstammdatenregister data for Germany from `open-MaStR (February 25, 2025)  <https://zenodo.org/records/14783581>`__.
 
+* Drop support for Python 3.9, add support for Python 3.13. Minimum required Python version is now 3.10.
+
+
 `v0.7.1 <https://github.com/PyPSA/powerplantmatching/releases/tag/v0.7.1>`__ (30th January 2024)
 =================================================================================================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ authors = [{ name = "Fabian Hofmann (FIAS)", email = "fabianmarikhofmann@gmail.c
 { name = "Fabian Gotzens (FZ Jülich)" }]
 license = { file = "LICENSE" }
 classifiers=[
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
@@ -23,7 +23,7 @@ classifiers=[
     "Operating System :: OS Independent",
 ]
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
     "numpy",
@@ -110,7 +110,7 @@ select = [
 
 # Add basic mypy configuration
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.13"
 warn_unused_configs = true
 disallow_untyped_defs = false
 disallow_incomplete_defs = false


### PR DESCRIPTION
## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [n/a] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
