### PR TITLE
Introduces customisable capacity_threshold for MASTR dataset

### DIFF
--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -2287,7 +2287,7 @@ def MASTR(
 
     config = get_config() if config is None else config
 
-    THRESHOLD_KW = 100  # noqa: F841
+    THRESHOLD_KW = config["MASTR"].get("capacity_threshold", 0.1) * 1e3  # noqa: F841
 
     RENAME_COLUMNS = {
         "EinheitMastrNummer": "projectID",

--- a/powerplantmatching/package_data/config.yaml
+++ b/powerplantmatching/package_data/config.yaml
@@ -41,8 +41,8 @@ fully_included_sources:
   - GEM: not (Country == 'Germany' and Fueltype in ['Solar', 'Wind'])
   # battery in Germany is covered by MASTR
   - EESI: Fueltype != 'Hydro' and not (Country == 'Germany' and Fueltype == 'Battery')
-  # exclude units smaller than 100 kW (low total capacity) and take nuclear from other datasets (good matching)
-  - MASTR: Capacity >= 0.1 and Fueltype != 'Nuclear'
+  # take nuclear from other datasets (good matching)
+  - MASTR: Fueltype != 'Nuclear'
   # take small hydro outside Germany from OPSD (highest coverage)
   - OPSD: Country != 'Germany' and Capacity < 1 and Capacity >= 0.1 and Fueltype == 'Hydro'
   - BEYONDCOAL
@@ -225,6 +225,7 @@ MASTR:
   net_capacity: true
   reliability_score: 7
   status: ["In Betrieb", "In Planung", "Endgültig stillgelegt", "Vorübergehend stillgelegt"]
+  capacity_threshold: 0.1  # all values below will be filtered out, given in MW
   fn: bnetza_open_mastr_2025-02-09.zip
   url: https://zenodo.org/records/14783581/files/bnetza_open_mastr_2025-02-09.zip
 EESI:


### PR DESCRIPTION
Closes #268.

## Changes proposed in this Pull Request

* adds a customisable "capacity_threshold" to the config instead of the hard-coded "THRESHOLD_KW" for the `MASTR()` data importer
* removes possibly misleading comment regarding which capacities are (not) filtered out from "fully_included_sources: MASTR"

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release_notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license and have added my name to the `docs/contributors.md`.
