### PR TITLE
MASTR: load any dated open-mastr dump (date-agnostic paths + glob fn)

### DIFF
--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -2408,8 +2408,12 @@ def MASTR(
 
     cols = ["NutzbareSpeicherkapazitaet", "VerknuepfteEinheit"]
     with ZipFile(fn, "r") as file:
-        fn_storage_units = (
-            "bnetza_open_mastr_2025-02-09/bnetza_mastr_storage_units_raw.csv"
+        # Match by suffix rather than a hardcoded dated folder, so newer
+        # open-mastr dumps (different bnetza_open_mastr_<date>/ prefix) load.
+        fn_storage_units = next(
+            name
+            for name in file.namelist()
+            if name.endswith("bnetza_mastr_storage_units_raw.csv")
         )
         storage_units = pd.read_csv(file.open(fn_storage_units), usecols=cols)
 
@@ -2473,8 +2477,16 @@ def MASTR(
             parse_columns=PARSE_COLUMNS,
         )
         .assign(
+            # ThermischeNutzleistung is present in the Zenodo CSV dump but absent
+            # from the open-mastr bulk export; fall back to KwkMastrNummer alone.
             Set=lambda df: df["Set"].where(
-                df["KwkMastrNummer"].isna() & df["ThermischeNutzleistung"].isna(), "CHP"
+                df["KwkMastrNummer"].isna()
+                & (
+                    df["ThermischeNutzleistung"].isna()
+                    if "ThermischeNutzleistung" in df.columns
+                    else True
+                ),
+                "CHP",
             ),
         )
     )

--- a/powerplantmatching/package_data/config.yaml
+++ b/powerplantmatching/package_data/config.yaml
@@ -226,7 +226,12 @@ MASTR:
   reliability_score: 7
   status: ["In Betrieb", "In Planung", "Endgültig stillgelegt", "Vorübergehend stillgelegt"]
   capacity_threshold: 0.1  # all values below will be filtered out, given in MW
-  fn: bnetza_open_mastr_2025-02-09.zip
+  # fn may be a glob: when it contains a wildcard the most recent matching
+  # local bnetza_open_mastr_<date>.zip is auto-selected (ISO dates sort
+  # chronologically, so the newest wins). url is the frozen Zenodo seed,
+  # downloaded only when no local match exists, so it never clobbers a newer
+  # local build. Use a literal filename to pin one specific dump instead.
+  fn: bnetza_open_mastr_*.zip
   url: https://zenodo.org/records/14783581/files/bnetza_open_mastr_2025-02-09.zip
 EESI:
   net_capacity: true

--- a/powerplantmatching/utils.py
+++ b/powerplantmatching/utils.py
@@ -10,7 +10,9 @@ import multiprocessing
 import os
 import re
 from ast import literal_eval as liteval
+from glob import glob
 from importlib.metadata import version
+from urllib.parse import urlparse
 
 import country_converter as coco
 import numpy as np
@@ -76,7 +78,24 @@ def get_raw_file(name, update=False, config=None, skip_retrieve=False):
     if config is None:
         config = get_config()
     df_config = config[name]
-    path = _data_in(df_config["fn"])
+    fn = df_config["fn"]
+
+    # A glob pattern in `fn` selects the most recent matching local file
+    # (e.g. a locally built, dated dump). ISO-dated filenames sort
+    # chronologically, so the last match is the newest. Falls back to
+    # downloading the URL's basename when nothing local matches.
+    if any(c in fn for c in "*?["):
+        matches = sorted(glob(_data_in(fn)))
+        if matches:
+            # The newest local dated build is authoritative. The URL is a
+            # frozen seed (e.g. the last Zenodo dump) that can never be newer
+            # than a local build, so honour the local match even when
+            # update=True; otherwise a forced refresh silently regresses to
+            # stale data.
+            return matches[-1]
+        path = _data_in(os.path.basename(urlparse(df_config["url"]).path))
+    else:
+        path = _data_in(fn)
 
     if (not os.path.exists(path) or update) and not skip_retrieve:
         url = df_config["url"]


### PR DESCRIPTION
## What

Makes the `MASTR()` loader work with **any** dated `open_mastr` dump instead of only the hardcoded `bnetza_open_mastr_2025-02-09` release. Fixes parts 2 and 3 of #299.

## Why

Today the loader cannot consume a newer MaStR dump even if you point the config at one:

1. The storage-units CSV is read from a hardcoded path that embeds the release date, so a newer dump (different `bnetza_open_mastr_<date>/` inner folder) raises `KeyError`.
2. `ThermischeNutzleistung` exists in the Zenodo CSV dump but not in the `open_mastr` bulk export, so a non-Zenodo-shaped dump breaks the CHP-detection assign.

See #299 for the full description.

## Changes

- **`data.py`** — match `bnetza_mastr_storage_units_raw.csv` by suffix rather than the hardcoded dated folder prefix.
- **`data.py`** — CHP detection falls back to `KwkMastrNummer` alone when `ThermischeNutzleistung` is absent.
- **`utils.py` (`get_raw_file`)** — a glob `fn` selects the newest matching local file (ISO dates sort chronologically); falls back to downloading the URL's basename when nothing local matches. Non-glob `fn` is unchanged.
- **`config.yaml`** — default `MASTR.fn` to the glob `bnetza_open_mastr_*.zip`, keeping the frozen Zenodo `url` as the download seed.

## Compatibility

Behavior-preserving on the current Zenodo dump: a fresh checkout has no local match, so `get_raw_file` falls back to downloading `bnetza_open_mastr_2025-02-09.zip`, and the suffix match reads the same inner CSV as before. Pin a specific dump by setting `fn` to a literal filename.

Not included here (deliberately, to keep this focused): the optional helper that rebuilds a current dump from the `open_mastr` bulk export. Happy to add it in a follow-up if maintainers want in-repo refresh tooling.

## Test plan

- [x] `import powerplantmatching` / module parse
- [ ] Maintainer CI (Duke/Java-gated tests)
