### PR TITLE
include OSM in matching

### DIFF
--- a/powerplantmatching/package_data/config.yaml
+++ b/powerplantmatching/package_data/config.yaml
@@ -31,6 +31,7 @@ matching_sources:
   - GEM: Capacity >= 3 and not (Country == 'Germany' and Fueltype  == 'Wind')
   # do not match units below 1 MW (2 MW for biogas, 3 MW for solar), exclude wind in Germany from any matching
   - MASTR: (Fueltype != 'Wind') and ((Fueltype == 'Solar' and Capacity >= 3) or (Fueltype == 'Biogas' and Capacity >= 2) or (Fueltype not in ['Solar', 'Biogas'] and Capacity >= 1))
+  - OSM: Capacity >= 1
   - EESI
   - GHR
 


### PR DESCRIPTION
<img width="2951" height="1203" alt="image" src="https://github.com/user-attachments/assets/8898ce76-99d6-4e63-a645-1c02cd460caa" />

<img width="2951" height="1111" alt="image" src="https://github.com/user-attachments/assets/613226ee-037c-414b-855b-24793b6c41f4" />

The coverage of the OSM is not great, but doesn't hurt to include in the matching.